### PR TITLE
Fix build failure with Runelite update on 2021-06-16

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.35'
+def runeLiteVersion = '1.7.12'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
@@ -15,8 +15,8 @@ public class FixedHideChatConstants
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_NPC = new AbstractMap.SimpleEntry<>(
-		WidgetInfo.DIALOG_NPC.getGroupId(),
-		WidgetInfo.DIALOG_NPC.getChildId()
+		WidgetID.DIALOG_NPC_GROUP_ID,
+		0
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_PLAYER = new AbstractMap.SimpleEntry<>(

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -14,6 +14,7 @@ import net.runelite.api.events.BeforeRender;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.KeyManager;
@@ -29,6 +30,9 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 {
 	@Inject
 	private Client client;
+
+	@Inject
+	private ClientThread clientThread;
 
 	@Inject
 	private KeyManager keyManager;
@@ -54,7 +58,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		lastMenu = 0;
 
 		// Reset widgets
-		resetWidgets();
+		clientThread.invoke(this::resetWidgets);
 	}
 
 	@Override


### PR DESCRIPTION
In the latest update, the `WidgetInfo.DIALOG_NPC` enum member was removed.  I replaced its uses with its prior definition.

This patch also moves the `resetWidgets` call onto the client thread as it resizes widgets, and was failing with assertions enabled (i.e. while I was using developer mode for testing).