### PR TITLE
Fix plugin and small improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*.java]
+indent_style = tab
+indent_size = 4

--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,13 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.27-SNAPSHOT'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 
-	compileOnly 'org.projectlombok:lombok:1.18.20'
-	annotationProcessor 'org.projectlombok:lombok:1.18.20'
+	compileOnly 'org.projectlombok:lombok:1.18.30'
+	annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
 	testImplementation 'junit:junit:4.12'
 	testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
@@ -25,8 +25,8 @@ dependencies {
 
 group = 'io.github.deathbeam.plugins.fixedhidechat'
 version = '1.0'
-sourceCompatibility = '1.8'
 
 tasks.withType(JavaCompile) {
 	options.encoding = 'UTF-8'
+	options.release.set(11)
 }

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConfig.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConfig.java
@@ -1,8 +1,7 @@
 package io.github.deathbeam.plugins.fixedhidechat;
 
-import net.runelite.client.config.Config;
-import net.runelite.client.config.ConfigGroup;
-import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.*;
+import java.awt.event.*;
 
 @ConfigGroup("FixedHideChat")
 public interface FixedHideChatConfig extends Config
@@ -16,5 +15,16 @@ public interface FixedHideChatConfig extends Config
 	default boolean resizeViewport()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+			keyName = "hideChatHotkey",
+			name = "Hotkey",
+			description = "Hotkey used to hide the chat.<br>"
+					+ "Can be a combination of keys (e.g. ctrl+L). Set the key to 'Not set' to disable this setting.",
+			position = 1
+	)
+	default Keybind hideChatHotkey() {
+		return new Keybind(KeyEvent.VK_ESCAPE, 0);
 	}
 }

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConfig.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConfig.java
@@ -1,0 +1,20 @@
+package io.github.deathbeam.plugins.fixedhidechat;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+@ConfigGroup("FixedHideChat")
+public interface FixedHideChatConfig extends Config
+{
+	@ConfigItem(
+			position = 0,
+			keyName = "resizeViewport",
+			name = "Resize viewport",
+			description = "Resize viewport when opening/closing chat"
+	)
+	default boolean resizeViewport()
+	{
+		return false;
+	}
+}

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
@@ -45,16 +45,6 @@ public class FixedHideChatConstants
 		0
 	);
 
-	private static final Map.Entry<Integer, Integer>  THEATRE_OF_BLOOD_DARK_OVERLAY_PARENT = new AbstractMap.SimpleEntry<>(
-		28,
-		0
-	);
-
-	private static final Map.Entry<Integer, Integer>  THEATRE_OF_BLOOD_DARK_OVERLAY_BODY = new AbstractMap.SimpleEntry<>(
-		28,
-		1
-	);
-
 	static final Map.Entry<Integer, Integer>  FIXED_MAIN = new AbstractMap.SimpleEntry<>(
 		InterfaceID.FIXED_VIEWPORT,
 		9
@@ -62,6 +52,11 @@ public class FixedHideChatConstants
 
 	static final int DEFAULT_VIEW_HEIGHT = 334;
 	static final int EXPANDED_VIEW_HEIGHT = 476;
+	static final int BANK_X = 12;
+	static final int BANK_Y = 2;
+	// This is the VIEW_HEIGHT minus the BANK_Y minus 1 since there is a gap of 1 pixel at the bottom without the plugin.
+	static final int DEFAULT_VIEW_WIDGET_HEIGHT = DEFAULT_VIEW_HEIGHT - BANK_Y - 1;
+	static final int EXPANDED_VIEW_WIDGET_HEIGHT = EXPANDED_VIEW_HEIGHT - BANK_Y - 1;
 
 	static final Set<Map.Entry<Integer, Integer>> AUTO_EXPAND_WIDGETS = ImmutableSet
 		.<Map.Entry<Integer, Integer>>builder()
@@ -76,7 +71,5 @@ public class FixedHideChatConstants
 	static final Set<Map.Entry<Integer, Integer>> TO_CONTRACT_WIDGETS = ImmutableSet
 		.<Map.Entry<Integer, Integer>>builder()
 		.add(FIXED_VIEWPORT_BANK_POPUP_CONTAINER)
-		.add(THEATRE_OF_BLOOD_DARK_OVERLAY_PARENT)
-		.add(THEATRE_OF_BLOOD_DARK_OVERLAY_BODY)
 		.build();
 }

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
@@ -4,45 +4,44 @@ import com.google.common.collect.ImmutableSet;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Set;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetID;
-import net.runelite.api.widgets.WidgetInfo;
+
+import net.runelite.api.widgets.*;
 
 public class FixedHideChatConstants
 {
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG = new AbstractMap.SimpleEntry<>(
-		WidgetInfo.DIALOG_OPTION.getGroupId(),
-		WidgetInfo.DIALOG_OPTION.getChildId()
+		InterfaceID.DIALOG_OPTION,
+		0
 	);
 
-	// Wrong PIN popup, idk what else
+	// Wrong PIN popup, idk what else; S162.565 (ID: 10617397)
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_SPECIAL = new AbstractMap.SimpleEntry<>(
-		WidgetID.CHATBOX_GROUP_ID,
-		559
+		InterfaceID.CHATBOX,
+		565
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_NPC = new AbstractMap.SimpleEntry<>(
-		WidgetID.DIALOG_NPC_GROUP_ID,
+		InterfaceID.DIALOG_NPC,
 		0
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_PLAYER = new AbstractMap.SimpleEntry<>(
-		WidgetInfo.DIALOG_PLAYER.getGroupId(),
-		WidgetInfo.DIALOG_PLAYER.getChildId()
+		InterfaceID.DIALOG_PLAYER,
+		0
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_SPRITE = new AbstractMap.SimpleEntry<>(
-		WidgetInfo.DIALOG_SPRITE.getGroupId(),
-		WidgetInfo.DIALOG_SPRITE.getChildId()
+		InterfaceID.DIALOG_SPRITE,
+		0
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_CONTAINER = new AbstractMap.SimpleEntry<>(
-		WidgetInfo.CHATBOX_CONTAINER.getGroupId(),
-		WidgetInfo.CHATBOX_CONTAINER.getChildId()
+		ComponentID.CHATBOX_CONTAINER,
+		0
 	);
 
 	private static final Map.Entry<Integer, Integer>  FIXED_VIEWPORT_BANK_POPUP_CONTAINER = new AbstractMap.SimpleEntry<>(
-		WidgetInfo.BANK_CONTAINER.getGroupId(),
+		ComponentID.BANK_CONTAINER,
 		0
 	);
 
@@ -57,7 +56,7 @@ public class FixedHideChatConstants
 	);
 
 	static final Map.Entry<Integer, Integer>  FIXED_MAIN = new AbstractMap.SimpleEntry<>(
-		WidgetID.FIXED_VIEWPORT_GROUP_ID,
+		InterfaceID.FIXED_VIEWPORT,
 		9
 	);
 

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
@@ -45,6 +45,11 @@ public class FixedHideChatConstants
 		0
 	);
 
+	private static final Map.Entry<Integer, Integer>  FIXED_VIEWPORT_SEED_VAULT_INVENTORY_ITEM_CONTAINER = new AbstractMap.SimpleEntry<>(
+		ComponentID.SEED_VAULT_INVENTORY_ITEM_CONTAINER,
+		0
+	);
+
 	static final Map.Entry<Integer, Integer>  FIXED_MAIN = new AbstractMap.SimpleEntry<>(
 		InterfaceID.FIXED_VIEWPORT,
 		9
@@ -71,5 +76,6 @@ public class FixedHideChatConstants
 	static final Set<Map.Entry<Integer, Integer>> TO_CONTRACT_WIDGETS = ImmutableSet
 		.<Map.Entry<Integer, Integer>>builder()
 		.add(FIXED_VIEWPORT_BANK_POPUP_CONTAINER)
+		.add(FIXED_VIEWPORT_SEED_VAULT_INVENTORY_ITEM_CONTAINER)
 		.build();
 }

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -42,6 +42,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 
 	private int lastMenu = 0;
 	private boolean hideChat = true;
+	private boolean hideChatPrevious = hideChat;
 
 	@Override
 	protected void startUp() throws Exception
@@ -98,14 +99,13 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		final Widget bankWidget = client.getWidget(ComponentID.BANK_CONTAINER);
 		if (bankWidget != null && !bankWidget.isSelfHidden())
 		{
-			// If changeBankProperties is not called before the script and the chatbox is open, then a tag tab briefly shows over the 'swap' button
-			changeBankProperties(bankWidget, BANK_X);
 			// call [clientscript,bankmain_init] because otherwise the tag tabs don't extend properly
-			Widget w = client.getWidget(ComponentID.BANK_CONTAINER);
-			if (w != null)
+			// but don't call it every frame because then performance tanks
+			// Causes a very slight flicker of the tag tab above the swap button sadly when opening the bag without the chat hidden
+			if (hideChatPrevious != hideChat)
 			{
-				client.createScriptEvent(w.getOnLoadListener())
-						.setSource(w)
+				client.createScriptEvent(bankWidget.getOnLoadListener())
+						.setSource(bankWidget)
 						.run();
 			}
 			changeBankProperties(bankWidget, BANK_X);
@@ -150,6 +150,8 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 			// Hide/show chat messages
 			chatboxMessages.setHidden(!found);
 		}
+
+		hideChatPrevious = hideChat;
 	}
 
 	@Subscribe
@@ -171,7 +173,8 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		}
 	}
 
-	private void changeBankProperties(Widget bankWidget, int xPosition) {
+	private void changeBankProperties(Widget bankWidget, int xPosition)
+	{
 		bankWidget.setOriginalX(xPosition);
 		bankWidget.setOriginalY(BANK_Y);
 		bankWidget.setXPositionMode(WidgetPositionMode.ABSOLUTE_LEFT);

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -12,8 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.BeforeRender;
 import net.runelite.api.events.MenuOptionClicked;
-import net.runelite.api.widgets.Widget;
-import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.*;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.input.KeyListener;
@@ -92,7 +91,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		}
 
 		// Bank container sometimes moves offscreen on resize and quick inputs, workaround
-		final Widget bankWidget = client.getWidget(WidgetInfo.BANK_CONTAINER);
+		final Widget bankWidget = client.getWidget(ComponentID.BANK_CONTAINER);
 
 		if (bankWidget != null && !bankWidget.isSelfHidden())
 		{
@@ -103,7 +102,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		// Expand the view height
 		setViewSizeTo(DEFAULT_VIEW_HEIGHT, EXPANDED_VIEW_HEIGHT);
 
-		final Widget chatboxMessages = client.getWidget(WidgetInfo.CHATBOX);
+		final Widget chatboxMessages = client.getWidget(ComponentID.CHATBOX_FRAME);
 
 		if (chatboxMessages != null)
 		{
@@ -112,9 +111,9 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 			// Check if any auto-expand interface is open
 			if (!found)
 			{
-				for (final Map.Entry<Integer, Integer> widgetInfo : AUTO_EXPAND_WIDGETS)
+				for (final Map.Entry<Integer, Integer> widgets : AUTO_EXPAND_WIDGETS)
 				{
-					final Widget widget = client.getWidget(widgetInfo.getKey(), widgetInfo.getValue());
+					final Widget widget = client.getWidget(widgets.getKey(), widgets.getValue());
 
 					if (widget != null && !widget.isSelfHidden())
 					{
@@ -142,7 +141,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 			return;
 		}
 
-		final Widget chatboxMessages = client.getWidget(WidgetInfo.CHATBOX);
+		final Widget chatboxMessages = client.getWidget(ComponentID.CHATBOX_FRAME);
 		final int newMenu = event.getWidgetId();
 		hideChat = true;
 
@@ -189,9 +188,9 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 
 	private void setWidgetsSizeTo(final int originalHeight, final int newHeight)
 	{
-		for (final Map.Entry<Integer, Integer> widgetInfo : TO_CONTRACT_WIDGETS)
+		for (final Map.Entry<Integer, Integer> widgets : TO_CONTRACT_WIDGETS)
 		{
-			final Widget widget = client.getWidget(widgetInfo.getKey(), widgetInfo.getValue());
+			final Widget widget = client.getWidget(widgets.getKey(), widgets.getValue());
 
 			if (widget != null && !widget.isSelfHidden())
 			{
@@ -202,7 +201,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 
 	private void setViewSizeTo(final int originalHeight, final int newHeight)
 	{
-		final Widget viewport = client.getWidget(WidgetInfo.FIXED_VIEWPORT);
+		final Widget viewport = client.getWidget(ComponentID.FIXED_VIEWPORT_FIXED_VIEWPORT);
 
 		if (viewport != null)
 		{
@@ -238,7 +237,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		setWidgetsSizeTo(EXPANDED_VIEW_HEIGHT, DEFAULT_VIEW_HEIGHT);
 
 		// Show the chat messages widget again
-		final Widget chatboxMessages = client.getWidget(WidgetInfo.CHATBOX);
+		final Widget chatboxMessages = client.getWidget(ComponentID.CHATBOX_FRAME);
 
 		if (chatboxMessages != null)
 		{

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -3,6 +3,7 @@ package io.github.deathbeam.plugins.fixedhidechat;
 import static io.github.deathbeam.plugins.fixedhidechat.FixedHideChatConstants.AUTO_EXPAND_WIDGETS;
 import static io.github.deathbeam.plugins.fixedhidechat.FixedHideChatConstants.DEFAULT_VIEW_HEIGHT;
 import static io.github.deathbeam.plugins.fixedhidechat.FixedHideChatConstants.EXPANDED_VIEW_HEIGHT;
+import static io.github.deathbeam.plugins.fixedhidechat.FixedHideChatConstants.BANK_X;
 import static io.github.deathbeam.plugins.fixedhidechat.FixedHideChatConstants.BANK_Y;
 import static io.github.deathbeam.plugins.fixedhidechat.FixedHideChatConstants.DEFAULT_VIEW_WIDGET_HEIGHT;
 import static io.github.deathbeam.plugins.fixedhidechat.FixedHideChatConstants.EXPANDED_VIEW_WIDGET_HEIGHT;
@@ -95,11 +96,10 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 
 		// Bank container sometimes moves offscreen on resize and quick inputs, workaround
 		final Widget bankWidget = client.getWidget(ComponentID.BANK_CONTAINER);
-
 		if (bankWidget != null && !bankWidget.isSelfHidden())
 		{
 			// If changeBankProperties is not called before the script and the chatbox is open, then a tag tab briefly shows over the 'swap' button
-			changeBankProperties(bankWidget);
+			changeBankProperties(bankWidget, BANK_X);
 			// call [clientscript,bankmain_init] because otherwise the tag tabs don't extend properly
 			Widget w = client.getWidget(ComponentID.BANK_CONTAINER);
 			if (w != null)
@@ -108,7 +108,14 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 						.setSource(w)
 						.run();
 			}
-			changeBankProperties(bankWidget);
+			changeBankProperties(bankWidget, BANK_X);
+		}
+
+		// The seed vault container sometimes moves offscreen on resize and quick inputs, workaround
+		final Widget seedVaultWidget = client.getWidget(ComponentID.SEED_VAULT_INVENTORY_ITEM_CONTAINER);
+		if (seedVaultWidget != null && !seedVaultWidget.isSelfHidden())
+		{
+			changeBankProperties(seedVaultWidget, 6);
 		}
 
 		// Expand the view height
@@ -164,8 +171,8 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		}
 	}
 
-	private void changeBankProperties(Widget bankWidget) {
-		bankWidget.setOriginalX(12);
+	private void changeBankProperties(Widget bankWidget, int xPosition) {
+		bankWidget.setOriginalX(xPosition);
 		bankWidget.setOriginalY(BANK_Y);
 		bankWidget.setXPositionMode(WidgetPositionMode.ABSOLUTE_LEFT);
 		bankWidget.setYPositionMode(WidgetPositionMode.ABSOLUTE_TOP);

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -108,14 +108,14 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 						.setSource(bankWidget)
 						.run();
 			}
-			changeBankProperties(bankWidget, BANK_X);
+			changeWidgetXY(bankWidget, BANK_X);
 		}
 
 		// The seed vault container sometimes moves offscreen on resize and quick inputs, workaround
 		final Widget seedVaultWidget = client.getWidget(ComponentID.SEED_VAULT_INVENTORY_ITEM_CONTAINER);
 		if (seedVaultWidget != null && !seedVaultWidget.isSelfHidden())
 		{
-			changeBankProperties(seedVaultWidget, 6);
+			changeWidgetXY(seedVaultWidget, 6);
 		}
 
 		// Expand the view height
@@ -173,13 +173,13 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		}
 	}
 
-	private void changeBankProperties(Widget bankWidget, int xPosition)
+	private void changeWidgetXY(Widget widget, int xPosition)
 	{
-		bankWidget.setOriginalX(xPosition);
-		bankWidget.setOriginalY(BANK_Y);
-		bankWidget.setXPositionMode(WidgetPositionMode.ABSOLUTE_LEFT);
-		bankWidget.setYPositionMode(WidgetPositionMode.ABSOLUTE_TOP);
-		bankWidget.revalidateScroll();
+		widget.setOriginalX(xPosition);
+		widget.setOriginalY(BANK_Y);
+		widget.setXPositionMode(WidgetPositionMode.ABSOLUTE_LEFT);
+		widget.setYPositionMode(WidgetPositionMode.ABSOLUTE_TOP);
+		widget.revalidateScroll();
 	}
 
 	private static void changeWidgetHeight(int originalHeight, int newHeight, Widget widget)

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -12,12 +12,15 @@ import static io.github.deathbeam.plugins.fixedhidechat.FixedHideChatConstants.T
 import java.awt.event.KeyEvent;
 import java.util.*;
 import javax.inject.Inject;
+
+import com.google.inject.*;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.BeforeRender;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.*;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.config.*;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.input.KeyListener;
 import net.runelite.client.input.KeyManager;
@@ -33,6 +36,9 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 {
 	@Inject
 	private Client client;
+
+	@Inject
+	private FixedHideChatConfig config;
 
 	@Inject
 	private ClientThread clientThread;
@@ -118,8 +124,13 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 			changeWidgetXY(seedVaultWidget, 6);
 		}
 
-		// Expand the view height
-		setViewSizeTo(DEFAULT_VIEW_HEIGHT, EXPANDED_VIEW_HEIGHT);
+		if (!hideChat && config.resizeViewport())
+		{
+			setViewSizeTo(EXPANDED_VIEW_HEIGHT, DEFAULT_VIEW_HEIGHT);
+		} else	{
+			// Expand the view height
+			setViewSizeTo(DEFAULT_VIEW_HEIGHT, EXPANDED_VIEW_HEIGHT);
+		}
 
 		final Widget chatboxMessages = client.getWidget(ComponentID.CHATBOX_FRAME);
 
@@ -282,5 +293,11 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		{
 			chatboxMessages.setHidden(false);
 		}
+	}
+
+	@Provides
+	FixedHideChatConfig getConfig(ConfigManager configManager)
+	{
+		return configManager.getConfig(FixedHideChatConfig.class);
 	}
 }

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -184,7 +184,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		}
 	}
 
-	private void changeWidgetXY(Widget widget, int xPosition)
+	private static void changeWidgetXY(Widget widget, int xPosition)
 	{
 		widget.setOriginalX(xPosition);
 		widget.setOriginalY(BANK_Y);
@@ -193,14 +193,18 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		widget.revalidateScroll();
 	}
 
+	private static void setWidgetHeight(final Widget widget, final int height)
+    {
+			widget.setOriginalHeight(height);
+			widget.setHeightMode(WidgetSizeMode.ABSOLUTE);
+			widget.revalidateScroll();
+    }
+
 	private static void changeWidgetHeight(int originalHeight, int newHeight, Widget widget)
 	{
 		if (widget.getHeight() == originalHeight)
 		{
-			widget.setOriginalHeight(newHeight);
-			widget.setHeightMode(WidgetSizeMode.ABSOLUTE);
-			widget.revalidateScroll();
-
+			setWidgetHeight(widget, newHeight);
 			final Widget[] nestedChildren = widget.getNestedChildren();
 
 			if (nestedChildren != null)
@@ -209,9 +213,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 				{
 					if (nestedChild.getHeight() == originalHeight)
 					{
-						nestedChild.setOriginalHeight(newHeight);
-						nestedChild.setHeightMode(WidgetSizeMode.ABSOLUTE);
-						nestedChild.revalidateScroll();
+						setWidgetHeight(nestedChild, newHeight);
 					}
 				}
 			}
@@ -224,9 +226,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 				{
 					if (child.getHeight() == originalHeight)
 					{
-						child.setOriginalHeight(newHeight);
-						child.setHeightMode(WidgetSizeMode.ABSOLUTE);
-						child.revalidateScroll();
+						setWidgetHeight(child, newHeight);
 					}
 				}
 			}
@@ -251,18 +251,14 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 
 		if (viewport != null)
 		{
-			viewport.setOriginalHeight(newHeight);
-			viewport.setHeightMode(WidgetSizeMode.ABSOLUTE);
-			viewport.revalidateScroll();
+			setWidgetHeight(viewport, newHeight);
 		}
 
 		final Widget fixedMain = client.getWidget(FIXED_MAIN.getKey(), FIXED_MAIN.getValue());
 
 		if (fixedMain != null && fixedMain.getHeight() == originalHeight)
 		{
-			fixedMain.setOriginalHeight(newHeight);
-			fixedMain.setHeightMode(WidgetSizeMode.ABSOLUTE);
-			fixedMain.revalidateScroll();
+			setWidgetHeight(fixedMain, newHeight);
 
 			final Widget[] staticChildren = fixedMain.getStaticChildren();
 

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -86,7 +86,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 	@Override
 	public void keyReleased(KeyEvent e)
 	{
-		if (!client.isResized() && e.getKeyCode() == KeyEvent.VK_ESCAPE && !hideChat)
+		if (!client.isResized() && e.getKeyCode() == config.hideChatHotkey().getKeyCode() && e.getModifiersEx() == config.hideChatHotkey().getModifiers() && !hideChat)
 		{
 			hideChat = true;
 			e.consume();


### PR DESCRIPTION
- Updates build.gradle
- Fixes the recent interface changes (closes #28, closes #29, closes #30, closes #31)
- Removes other deprecated APIs
- Adds the seed vault bank interface
- Adds the option to resize the viewport when closing the chat (closes #24)
- Adds the option to change the escape keybind to a user selected key (closes #23)

In the future I might look at:
- Split PMs randomly moving up and down. Could not replicate at this point, but I might have experienced it in the past.
- The voting interface going offscreen. This is a very common occurence, but there is not vote live so I could not fix this.

If you'd like me to make certain changes, drop commmits or would like to ask me why I opted for certain approaches, feel free to DM me on discord ``@YvesW``, @ me in the RL discord, or just do it here.