### PR TITLE
Toggleable chat through use of Hotkey

### DIFF
--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConfig.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConfig.java
@@ -18,13 +18,13 @@ public interface FixedHideChatConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideChatHotkey",
+			keyName = "hideChatToggleHotkey",
 			name = "Hotkey",
-			description = "Hotkey used to hide the chat.<br>"
+			description = "Hotkey used to toggle hiding the chat.<br>"
 					+ "Can be a combination of keys (e.g. ctrl+L). Set the key to 'Not set' to disable this setting.",
 			position = 1
 	)
-	default Keybind hideChatHotkey() {
+	default Keybind hideChatToggleHotkey() {
 		return new Keybind(KeyEvent.VK_ESCAPE, 0);
 	}
 }

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -80,23 +80,23 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 	@Override
 	public void keyTyped(KeyEvent e)
 	{
-		keyReleased(e);
+
 	}
 
 	@Override
 	public void keyPressed(KeyEvent e)
 	{
-		keyReleased(e);
+
 	}
 
 	@Override
 	public void keyReleased(KeyEvent e)
 	{
-		if (!client.isResized() && e.getKeyCode() == config.hideChatHotkey().getKeyCode() && e.getModifiersEx() == config.hideChatHotkey().getModifiers() && !hideChat)
+		if (!client.isResized() && e.getKeyCode() == config.hideChatToggleHotkey().getKeyCode() && e.getModifiersEx() == config.hideChatToggleHotkey().getModifiers())
 		{
-			hideChat = true;
+			hideChat = !hideChat;
 			e.consume();
-		}
+		} 
 	}
 
 	@Subscribe


### PR DESCRIPTION
Hello! Love the plugin.

- Update to allow for the hotkey to toggle the chat instead of just hiding it.
- Method renames to reflect toggle
- Removed call to keyReleased() method within keyPressed and keyTyped methods. This was causing the hotkey to be issued multiple times. Toggle will now only happen upon key release.