### PR TITLE
Hotfix to unhide chat when dialog is opened with object/player/npc

### DIFF
--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -197,14 +197,14 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onChatMessage(final ChatMessage event)
 	{
-		if (hideChat = false)
+		if (hideChat == false)
 		{
 			return;
 		}
 
 		final int messageType = event.ChatMessageType;
 		
-		if (messageType == 114 || messageType == 115) // Type 114 is NPC/player dialog, 115 is graphic/object dialog
+		if (hideChat == true && (messageType == 114 || messageType == 115)) // Type 114 is NPC/player dialog, 115 is graphic/object dialog
 		{
 			hideChat = false;
 		}

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -19,6 +19,7 @@ import net.runelite.api.Client;
 import net.runelite.api.events.BeforeRender;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.ChatMessage;
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.widgets.*;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.callback.ClientThread;

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.BeforeRender;
 import net.runelite.api.events.MenuOptionClicked;
+import net.runelite.api.events.ChatMessage;
 import net.runelite.api.widgets.*;
 import net.runelite.client.game.SpriteManager;
 import net.runelite.client.callback.ClientThread;
@@ -193,6 +194,22 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 		}
 	}
 
+	@Subscribe
+	public void onChatMessage(final ChatMessage event)
+	{
+		if (hideChat = false)
+		{
+			return;
+		}
+
+		final int messageType = event.ChatMessageType;
+		
+		if (messageType == 114 || messageType == 115) // Type 114 is NPC/player dialog, 115 is graphic/object dialog
+		{
+			hideChat = false;
+		}
+	}
+	
 	private static void changeWidgetXY(Widget widget, int xPosition)
 	{
 		widget.setOriginalX(xPosition);

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -197,12 +197,12 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onChatMessage(final ChatMessage chatMessage)
 	{
-		if (hideChat == false)
+		if (!hideChat)
 		{
 			return;
 		}
 		
-		if (hideChat == true && (chatMessage.getType() == ChatMessageType.DIALOG || chatMessage.getType() == ChatMessageType.MESBOX))
+		if (hideChat && (chatMessage.getType() == ChatMessageType.DIALOG || chatMessage.getType() == ChatMessageType.MESBOX))
 		{
 			hideChat = false;
 		}

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -195,16 +195,14 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 	}
 
 	@Subscribe
-	public void onChatMessage(final ChatMessage event)
+	public void onChatMessage(final ChatMessage chatMessage)
 	{
 		if (hideChat == false)
 		{
 			return;
 		}
-
-		final int messageType = event.ChatMessageType;
 		
-		if (hideChat == true && (messageType == 114 || messageType == 115)) // Type 114 is NPC/player dialog, 115 is graphic/object dialog
+		if (hideChat == true && (chatMessage.getType() == ChatMessageType.DIALOG || chatMessage.getType() == ChatMessageType.MESBOX))
 		{
 			hideChat = false;
 		}


### PR DESCRIPTION
Addresses issue #52 where the chatbox is not opening when a dialog is started. 

Adds a new subscription to ChatMessage events. When a message type 114 (npc/player dialog) or 115 (object/graphic dialog) occurs, the chatbox is unhidden.

This is a very rudimentary fix attempt, and I was unable to test it fully due to my own system limitations, but I thought it might be a step in the right direction.