### PR TITLE
Update chat constants to fix broken plugin

### DIFF
--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
@@ -55,6 +55,12 @@ public class FixedHideChatConstants
 		9
 	);
 
+	// Cannot find a suitable constant for 270, this is for "Making" interfaces (glassblowing, potion making, smelting)
+	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_MAKE_X = new AbstractMap.SimpleEntry<>(
+		270,
+		1
+	);
+
 	static final int DEFAULT_VIEW_HEIGHT = 334;
 	static final int EXPANDED_VIEW_HEIGHT = 476;
 	static final int BANK_X = 12;
@@ -71,6 +77,7 @@ public class FixedHideChatConstants
 		.add(CHATBOX_MESSAGES_DIALOG_NPC)
 		.add(CHATBOX_MESSAGES_DIALOG_PLAYER)
 		.add(CHATBOX_MESSAGES_DIALOG_SPRITE)
+		.add(CHATBOX_MESSAGES_MAKE_X)
 		.build();
 
 	static final Set<Map.Entry<Integer, Integer>> TO_CONTRACT_WIDGETS = ImmutableSet

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
@@ -16,8 +16,8 @@ public class FixedHideChatConstants
 
 	// Wrong PIN popup, idk what else; S162.565 (ID: 10617397)
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_SPECIAL = new AbstractMap.SimpleEntry<>(
-		InterfaceID.CHATBOX,
-		565
+		219,
+		1
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_NPC = new AbstractMap.SimpleEntry<>(
@@ -31,8 +31,8 @@ public class FixedHideChatConstants
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_SPRITE = new AbstractMap.SimpleEntry<>(
-		InterfaceID.DIALOG_SPRITE,
-		0
+		231,
+		2
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_CONTAINER = new AbstractMap.SimpleEntry<>(

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
@@ -16,7 +16,7 @@ public class FixedHideChatConstants
 
 	// Wrong PIN popup, idk what else; S162.565 (ID: 10617397)
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_SPECIAL = new AbstractMap.SimpleEntry<>(
-		219,
+		InterfaceID.DIALOG_OPTION,
 		1
 	);
 
@@ -31,7 +31,7 @@ public class FixedHideChatConstants
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_SPRITE = new AbstractMap.SimpleEntry<>(
-		231,
+		InterfaceID.DIALOG_NPC,
 		2
 	);
 

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
@@ -11,28 +11,28 @@ public class FixedHideChatConstants
 {
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG = new AbstractMap.SimpleEntry<>(
 		InterfaceID.DIALOG_OPTION,
-		0
+		1
 	);
 
 	// Wrong PIN popup, idk what else; S162.565 (ID: 10617397)
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_SPECIAL = new AbstractMap.SimpleEntry<>(
-		InterfaceID.DIALOG_OPTION,
-		1
+		InterfaceID.CHATBOX,
+		565
+	);
+
+	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_SPRITE = new AbstractMap.SimpleEntry<>(
+		InterfaceID.DIALOG_SPRITE,
+		2
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_NPC = new AbstractMap.SimpleEntry<>(
 		InterfaceID.DIALOG_NPC,
-		0
+		2
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_PLAYER = new AbstractMap.SimpleEntry<>(
 		InterfaceID.DIALOG_PLAYER,
 		0
-	);
-
-	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_SPRITE = new AbstractMap.SimpleEntry<>(
-		InterfaceID.DIALOG_NPC,
-		2
 	);
 
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_CONTAINER = new AbstractMap.SimpleEntry<>(


### PR DESCRIPTION
I tested this with a ring of dueling in my inventory using the "Rub" menu option, as well as just talking to various NPCs with my chatbox hidden, it seems to be functioning normally again.

Later commits include fix support for the chatbox to show when dropping valuable items, and when presented with a menu to make "x" amount of items such as potions, smelting ore, glassblowing, fletching, gem cutting, etc... 

I had to hard code the value "270" as I could not find an InterfaceID constant for 270 in the RuneLite API docs.  