### PR TITLE
Fix 'Contract' option in farming guild

### DIFF
--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
@@ -35,6 +35,12 @@ public class FixedHideChatConstants
 		0
 	);
 
+	// Fix for 'Contract' from Jane in Farming Guild
+	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_PLAYER_1 = new AbstractMap.SimpleEntry<>(
+		InterfaceID.DIALOG_PLAYER,
+		1
+	);
+
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_CONTAINER = new AbstractMap.SimpleEntry<>(
 		ComponentID.CHATBOX_CONTAINER,
 		0
@@ -78,6 +84,7 @@ public class FixedHideChatConstants
 		.add(CHATBOX_MESSAGES_DIALOG_PLAYER)
 		.add(CHATBOX_MESSAGES_DIALOG_SPRITE)
 		.add(CHATBOX_MESSAGES_MAKE_X)
+		.add(CHATBOX_MESSAGES_DIALOG_PLAYER_1)
 		.build();
 
 	static final Set<Map.Entry<Integer, Integer>> TO_CONTRACT_WIDGETS = ImmutableSet


### PR DESCRIPTION
Rebase of previous pull request. This will fix the 'Contract' option not opening the chatbox in the Farming Guild, and I assume other menu options like it but did not test. 