### PR TITLE
Improve chatbox widget pop-up coverage via recursive call

### DIFF
--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
@@ -34,7 +34,7 @@ public class FixedHideChatConstants
 	);
 
 	private static final Map.Entry<Integer, Integer>  FIXED_VIEWPORT_SEED_VAULT_INVENTORY_ITEM_CONTAINER = new AbstractMap.SimpleEntry<>(
-		631,
+		InterfaceID.SEED_VAULT,
 		1
 	);
 

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatConstants.java
@@ -9,41 +9,23 @@ import net.runelite.api.widgets.*;
 
 public class FixedHideChatConstants
 {
-	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG = new AbstractMap.SimpleEntry<>(
+	// 'Rub' option (S219.0) Duel rings, Slayer Rings, Burning Amulets, etc.
+	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_OPTION = new AbstractMap.SimpleEntry<>(
 		InterfaceID.DIALOG_OPTION,
-		1
+		0
 	);
 
-	// Wrong PIN popup, idk what else; S162.565 (ID: 10617397)
+	// A lot of other stuff, we recurse through this, it should catch any messages under (S162.566 ID: 10617398)
+	// Wrong PIN popup, Gauntlet Exit Prompt (S229.0 ID: 15007745), NPC Dialog (N231.0 ID: 5138816), Make-X (N270.0 ID: 17694720)... etc.
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_SPECIAL = new AbstractMap.SimpleEntry<>(
 		InterfaceID.CHATBOX,
-		565
+		566
 	);
 
-	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_SPRITE = new AbstractMap.SimpleEntry<>(
-		InterfaceID.DIALOG_SPRITE,
-		2
-	);
-
-	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_NPC = new AbstractMap.SimpleEntry<>(
-		InterfaceID.DIALOG_NPC,
-		2
-	);
-
-	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_PLAYER = new AbstractMap.SimpleEntry<>(
-		InterfaceID.DIALOG_PLAYER,
-		0
-	);
-
-	// Fix for 'Contract' from Jane in Farming Guild
-	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_DIALOG_PLAYER_1 = new AbstractMap.SimpleEntry<>(
-		InterfaceID.DIALOG_PLAYER,
-		1
-	);
-
+	// Bank Search Container
 	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_CONTAINER = new AbstractMap.SimpleEntry<>(
-		ComponentID.CHATBOX_CONTAINER,
-		0
+		InterfaceID.CHATBOX,
+		42
 	);
 
 	private static final Map.Entry<Integer, Integer>  FIXED_VIEWPORT_BANK_POPUP_CONTAINER = new AbstractMap.SimpleEntry<>(
@@ -52,19 +34,13 @@ public class FixedHideChatConstants
 	);
 
 	private static final Map.Entry<Integer, Integer>  FIXED_VIEWPORT_SEED_VAULT_INVENTORY_ITEM_CONTAINER = new AbstractMap.SimpleEntry<>(
-		ComponentID.SEED_VAULT_INVENTORY_ITEM_CONTAINER,
-		0
+		631,
+		1
 	);
 
 	static final Map.Entry<Integer, Integer>  FIXED_MAIN = new AbstractMap.SimpleEntry<>(
 		InterfaceID.FIXED_VIEWPORT,
 		9
-	);
-
-	// Cannot find a suitable constant for 270, this is for "Making" interfaces (glassblowing, potion making, smelting)
-	private static final Map.Entry<Integer, Integer>  CHATBOX_MESSAGES_MAKE_X = new AbstractMap.SimpleEntry<>(
-		270,
-		1
 	);
 
 	static final int DEFAULT_VIEW_HEIGHT = 334;
@@ -77,14 +53,9 @@ public class FixedHideChatConstants
 
 	static final Set<Map.Entry<Integer, Integer>> AUTO_EXPAND_WIDGETS = ImmutableSet
 		.<Map.Entry<Integer, Integer>>builder()
-		.add(CHATBOX_MESSAGES_DIALOG)
-		.add(CHATBOX_MESSAGES_SPECIAL)
+		.add(CHATBOX_MESSAGES_DIALOG_OPTION)
 		.add(CHATBOX_MESSAGES_CONTAINER)
-		.add(CHATBOX_MESSAGES_DIALOG_NPC)
-		.add(CHATBOX_MESSAGES_DIALOG_PLAYER)
-		.add(CHATBOX_MESSAGES_DIALOG_SPRITE)
-		.add(CHATBOX_MESSAGES_MAKE_X)
-		.add(CHATBOX_MESSAGES_DIALOG_PLAYER_1)
+		.add(CHATBOX_MESSAGES_SPECIAL)
 		.build();
 
 	static final Set<Map.Entry<Integer, Integer>> TO_CONTRACT_WIDGETS = ImmutableSet

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -1,5 +1,6 @@
 package io.github.deathbeam.plugins.fixedhidechat;
 
+import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.util.*;
 import javax.inject.Inject;
@@ -159,8 +160,18 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 			// Check if any auto-expand interface is open
 			if (!found) {
 				for (final Map.Entry<Integer, Integer> widgets : AUTO_EXPAND_WIDGETS) {
-					final Widget widget = client.getWidget(widgets.getKey(), widgets.getValue());
+					final Widget fairyRingSearch = client.getWidget(InterfaceID.CHATBOX, 38);
+					if (fairyRingSearch != null) {
+						Widget[] fairyRingArray = fairyRingSearch.getDynamicChildren();
+						if (fairyRingArray.length > 0) {
+							if (fairyRingArray[0] != null && fairyRingArray[0].getText().contains("fairy")) {
+								found = true;
+								break;
+							}
+						}
+					}
 
+					final Widget widget = client.getWidget(widgets.getKey(), widgets.getValue());
 					if (widget != null && !widget.isSelfHidden()) {
 						final Widget[] nestedChildren = widget.getNestedChildren();
 						final Widget[] staticChildren = widget.getStaticChildren();

--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -1,13 +1,10 @@
 package io.github.deathbeam.plugins.fixedhidechat;
 
-import java.awt.*;
 import java.awt.event.KeyEvent;
 import java.util.*;
 import javax.inject.Inject;
-import javax.swing.text.AbstractDocument;
 
 import com.google.inject.*;
-import jdk.jfr.ContentType;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.events.BeforeRender;


### PR DESCRIPTION
Edit: This will be my last pull request, at least for a while, so hopefully this covers most of it.

I added a recursive function `isWidgetFound` that will traverse through Widgets and their children (nested and static). This improves overall functionality of this plugin and also reduces the amount of constants required in `FixedHideChatPlugin.java`. 

Tested:
- Gauntlet Exit Prompt (previously broken)
- Skill level ups (previously broken)
- Combat level level ups (previously broken)
- GOTR 'no available inventory space' popup (previously broken)
- Seed vault resizing when searching
- Incorrect Bank Pin
- Bank search
- Fairy ring search
- General `Talk-To` with NPCs
- `Contract` farming guild and other similar popups (Pay NPC to watch crops, Slayer assignment, Get a skull from skull NPC)
- Glass blowing, gem cutting, fletching, potion making (Make-X type menus)
- NPC Contact spell
- Duel ring teleport type menus (Burning amulet, Slayer ring, Necklace of Passage)
- World hop warnings (Deadman, high risk, PVP)
- Searching Shelves / Bookcases / POH Tools
- Charge / Uncharge a weapon (Warped sceptre)
- Dropping / alching valuable items warning
- Repairing barrows armor on POH armor stand

Issues:
- Will have to lean on the community as there are too many things to test.