### PR TITLE
Use Keybind.matches so hotkey 'Not set' disables the hotkey.

### DIFF
--- a/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
+++ b/src/main/java/io/github/deathbeam/plugins/fixedhidechat/FixedHideChatPlugin.java
@@ -102,7 +102,7 @@ public class FixedHideChatPlugin extends Plugin implements KeyListener
 	@Override
 	public void keyReleased(KeyEvent e)
 	{
-		if (!client.isResized() && e.getKeyCode() == config.hideChatHotkey().getKeyCode() && e.getModifiersEx() == config.hideChatHotkey().getModifiers() && !hideChat)
+		if (!client.isResized() && config.hideChatHotkey().matches(e) && !hideChat)
 		{
 			hideChat = true;
 			e.consume();


### PR DESCRIPTION
Fixes #87.
The hotkey check compared keycodes manually. Keybind `Not set` is keycode 0, and keyTyped events always report keycode 0, so with the hotkey `Not set` any typed key matched and hid the chat. Switched to `matches()`, which returns false for `Not set` and handles modifier combos. No behavior change otherwise.